### PR TITLE
feat: Add hybrid CPU/GPU mode for extended context windows

### DIFF
--- a/models_config.json
+++ b/models_config.json
@@ -12,6 +12,9 @@
       "trust_remote_code": true,
       "effective_context_tokens": 131072,
       "max_context_tokens": 262144,
+      "kv_cache_mb_per_1k": 175,
+      "n_gpu_layers": 40,
+      "hybrid_mode": true,
       "default_params": {
         "temperature": 0.7,
         "max_tokens": 8192,
@@ -30,6 +33,9 @@
       "trust_remote_code": true,
       "effective_context_tokens": 65536,
       "max_context_tokens": 262144,
+      "kv_cache_mb_per_1k": 100,
+      "n_gpu_layers": -1,
+      "hybrid_mode": false,
       "default_params": {
         "temperature": 0.7,
         "max_tokens": 8192,
@@ -48,6 +54,9 @@
       "trust_remote_code": true,
       "effective_context_tokens": 32768,
       "max_context_tokens": 32768,
+      "kv_cache_mb_per_1k": 50,
+      "n_gpu_layers": -1,
+      "hybrid_mode": false,
       "default_params": {
         "temperature": 0.7,
         "max_tokens": 8192,
@@ -66,6 +75,9 @@
       "trust_remote_code": true,
       "effective_context_tokens": 16384,
       "max_context_tokens": 262144,
+      "kv_cache_mb_per_1k": 25,
+      "n_gpu_layers": -1,
+      "hybrid_mode": false,
       "default_params": {
         "temperature": 0.7,
         "max_tokens": 8192,
@@ -84,6 +96,9 @@
       "trust_remote_code": true,
       "effective_context_tokens": 131072,
       "max_context_tokens": 262144,
+      "kv_cache_mb_per_1k": 175,
+      "n_gpu_layers": 40,
+      "hybrid_mode": true,
       "default_params": {
         "temperature": 0.3,
         "max_tokens": 8192,


### PR DESCRIPTION
## Summary
- Implements hybrid CPU/GPU mode to leverage system RAM for dramatically larger context windows
- Adds per-model configuration for optimized memory usage and layer offloading
- Updates KV-cache estimates to realistic values based on modern GQA architecture

## Problem
The current implementation was limited to 50-60k token context windows even with 24GB VRAM due to:
1. Overly conservative KV-cache memory estimates (800MB/1k for 30B models vs actual ~175MB/1k)
2. Limited memory budget allocation (70% of available GPU memory)
3. No ability to leverage the 128GB system RAM for context storage

## Solution
This PR introduces a hybrid CPU/GPU mode that can be configured per-model, allowing:
- **30B models**: Use 40 GPU layers + CPU for ~128k token contexts
- **Smaller models**: Continue using full GPU with more realistic memory estimates
- **Flexible configuration**: Each model can specify its own `n_gpu_layers`, `kv_cache_mb_per_1k`, and `hybrid_mode` settings

## Key Changes

### 1. Per-Model Configuration (`models_config.json`)
- Added `hybrid_mode`: boolean flag to enable CPU/GPU split
- Added `n_gpu_layers`: configurable GPU layer offloading (40 for 30B, -1 for others)
- Added `kv_cache_mb_per_1k`: realistic KV-cache estimates per model size

### 2. Memory Calculation Updates (`llama_backend.py`)
- Hybrid mode uses system RAM for KV-cache storage
- Automatic RAM detection via psutil
- Separate calculation paths for GPU-only vs hybrid modes
- More realistic KV-cache estimates based on GQA architecture

### 3. Configuration Details
```json
"qwen3-30b-instruct": {
  "kv_cache_mb_per_1k": 175,  // Realistic for GQA
  "n_gpu_layers": 40,          // Offload 40 layers to GPU
  "hybrid_mode": true          // Enable CPU/GPU hybrid
}
```

## Expected Impact

### Context Window Improvements
- **30B model**: From ~5k tokens → ~128k tokens
- **7B model**: From ~50k tokens → ~100k+ tokens (with realistic estimates)
- **4B model**: Maintains full GPU performance with better estimates

### Performance Considerations
- Hybrid mode trades speed for context size (10-50x slower for CPU layers)
- GPU-only models maintain full performance with larger contexts
- Configurable per-model allows optimal balance for each use case

## Testing Recommendations
1. Test 30B model with hybrid mode enabled - should achieve 128k context
2. Test 7B model with updated estimates - should see 2x context improvement
3. Monitor actual memory usage vs estimates for further tuning
4. Benchmark inference speed in hybrid vs GPU-only modes

## Backwards Compatibility
- Models without new config fields fall back to conservative defaults
- Existing GPU-only behavior preserved for non-hybrid models
- No breaking changes to API or existing functionality