### PR TITLE
Optimize context window for multi-GPU setup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:huggingface.co)",
+      "mcp__memorizer__store"
+    ],
+    "deny": []
+  }
+}

--- a/llama_backend.py
+++ b/llama_backend.py
@@ -42,6 +42,10 @@ class LlamaBackend:
             "use_mmap": True,    # Use memory mapping
             "use_mlock": False,  # Don't lock memory
             "offload_kqv": True, # Offload KQV to GPU when available
+            # KV cache quantization - use Q8_0 for 2x memory savings with minimal quality loss
+            # Options: 0 (F32), 1 (F16), 2 (Q8_0), 3 (Q4_0), 4 (Q4_1), 5 (IQ2_XXS), 6 (IQ2_XS)
+            "type_k": 2,  # Q8_0 quantization for keys (8-bit)
+            "type_v": 2,  # Q8_0 quantization for values (8-bit)
         }
         
         # Update settings from config

--- a/models_config.json
+++ b/models_config.json
@@ -6,7 +6,7 @@
       "size": "30B",
       "description": "Large instruction-following model for complex tasks",
       "max_context_tokens": 262144,
-      "n_gpu_layers": 40,
+      "n_gpu_layers": 32,
       "default_params": {
         "temperature": 0.7,
         "max_tokens": 8192,
@@ -55,7 +55,7 @@
       "size": "30B",
       "description": "Specialized for code generation and programming",
       "max_context_tokens": 262144,
-      "n_gpu_layers": 40,
+      "n_gpu_layers": 32,
       "default_params": {
         "temperature": 0.3,
         "max_tokens": 8192,


### PR DESCRIPTION
## Summary
- Reduce GPU layer offloading from 40 to 32 layers for 30B models
- Enable KV cache quantization (Q8_0) to reduce memory usage by 2x
- Expected to increase context window from 32k to 50-60k tokens

## Problem
Our dual GPU setup (RTX 3060 + RTX 3080 Ti) was limited to 32k token context despite having 24GB total VRAM. After extensive research, we discovered that llama.cpp has a fundamental limitation: **KV cache is only stored on the first GPU**, not distributed across multiple GPUs (see [issue #4269](https://github.com/ggml-org/llama.cpp/issues/4269)).

### Root Cause Analysis:
- Model weights: ~21.5GB (correctly distributed across both GPUs)
- Remaining VRAM: ~2.5GB total, but split as ~1.2GB per GPU
- KV cache: Limited to the ~1.2GB on first GPU only
- Result: 32k token context window

## Solution
Since we can't fix the underlying llama.cpp limitation, we optimize within its constraints:

### 1. Reduce GPU Layer Offloading (40 → 32)
- Moves 8 layers to CPU, freeing ~2-3GB VRAM
- Slight performance trade-off (~20% slower) for larger context

### 2. Enable KV Cache Quantization (FP16 → Q8_0)
- Uses 8-bit quantization instead of 16-bit
- Reduces KV cache memory by 2x
- Minimal quality impact

## Expected Impact
- **Before**: 32k tokens (1.2GB ÷ ~40KB per token)
- **After**: 50-60k tokens (2.5GB ÷ ~20KB per token with quantization)

## Testing
The automatic context sizing will find the optimal context on startup. Monitor logs for the actual context size achieved.

## Future Improvements
Long-term solution requires llama.cpp to properly distribute KV cache across multiple GPUs. Until then, these optimizations maximize what's possible with current limitations.