### PR TITLE
Fix model manager quantization check

### DIFF
--- a/model_manager.py
+++ b/model_manager.py
@@ -135,9 +135,18 @@ class ModelManagerCLI:
         model_config = self.config["models"][model_id]
         model_name = model_config["name"]
         download_path = self.config["download_path"]
+        quantization = model_config.get("quantization", None)
         
-        # Check if already downloaded
-        if is_model_downloaded(model_name, download_path) and not force:
+        # Check if specific quantization is already downloaded
+        if quantization and not force:
+            model_dir = os.path.join(download_path, model_name.replace("/", "_"))
+            if os.path.exists(model_dir):
+                for file in os.listdir(model_dir):
+                    if file.endswith('.gguf') and quantization in file:
+                        console.print(f"[yellow]Model {model_id} with {quantization} is already downloaded[/yellow]")
+                        return True
+                console.print(f"[blue]Model {model_id} exists but {quantization} quantization not found. Downloading...[/blue]")
+        elif is_model_downloaded(model_name, download_path) and not force:
             console.print(f"[yellow]Model {model_id} is already downloaded[/yellow]")
             return True
         


### PR DESCRIPTION
## Summary
- Fixed model manager to properly check for specific quantization files before claiming model is downloaded
- Prevents issues where wrong quantization (e.g., Q4_K_M) exists but different one (e.g., Q3_K_S) is needed

## Context
After switching to Q3_K_S quantization to free up VRAM for larger context windows, the model manager would incorrectly report the model as already downloaded when it found Q4_K_M files, preventing the correct quantization from being downloaded.

## Changes
- Added quantization-specific checking in `download_model()` method
- Shows clear message when model exists but requested quantization is missing
- Properly downloads the specified quantization when needed

🤖 Generated with [Claude Code](https://claude.ai/code)