### PR TITLE
Improve qwen3-coder-30b stability and memory usage

### DIFF
--- a/models_config.json
+++ b/models_config.json
@@ -54,9 +54,9 @@
       "type": "coder",
       "size": "30B",
       "description": "Specialized for code generation and programming",
-      "max_context_tokens": 65536,
-      "n_gpu_layers": -1,
-      "quantization": "Q2_K",
+      "max_context_tokens": 32768,
+      "n_gpu_layers": 35,
+      "quantization": "Q3_K_M",
       "default_params": {
         "temperature": 0.3,
         "max_tokens": 8192,


### PR DESCRIPTION
## Summary
- Change quantization from Q2_K to Q3_K_M for better numerical stability
- Reduce context window from 65536 to 32768 tokens to lower memory pressure  
- Set n_gpu_layers to 35 instead of -1 to allow CPU fallback buffer

## Test plan
- [ ] Start server and verify model loads successfully with new Q3_K_M quantization
- [ ] Test inference under load to ensure CUDA crashes are resolved
- [ ] Verify memory usage is more stable with reduced context window

These changes address CUDA crashes during inference by reducing aggressive quantization that caused numerical instability under complex workloads.